### PR TITLE
protect all paths

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -9,6 +9,12 @@ log    /var/log/caddy_log.log
 root /www/
 browse
 
+jwt {
+    path /
+    allow role admin
+    publickey /public_key.pem
+}
+
 
 jwt {
     path /model-review/2019/test-group

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -11,7 +11,7 @@ browse
 
 jwt {
     path /
-    allow role admin
+    allow access_level admin
     publickey /public_key.pem
 }
 

--- a/caddy/Caddyfile.template
+++ b/caddy/Caddyfile.template
@@ -9,4 +9,10 @@ log    /var/log/caddy_log.log
 root /www/
 browse
 
+jwt {
+    path /
+    allow role admin
+    publickey /public_key.pem
+}
+
 ${jwt_rules}

--- a/caddy/Caddyfile.template
+++ b/caddy/Caddyfile.template
@@ -11,7 +11,7 @@ browse
 
 jwt {
     path /
-    allow role admin
+    allow access_level admin
     publickey /public_key.pem
 }
 


### PR DESCRIPTION
This locks down all paths for users without the `access_level=admin` claim. 