### PR TITLE
vimc-4230 move images to docker hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Within `nginx/` run
 ```
 ./build.sh
 export GIT_BRANCH_TAG=$(git symbolic-ref --short HEAD)
-docker pull docker.montagu.dide.ic.ac.uk:5000/montagu-static:${GIT_BRANCH_TAG}
-docker pull docker.montagu.dide.ic.ac.uk:5000/montagu-static-reverse-proxy:${GIT_BRANCH_TAG}
+docker pull vimc/montagu-static:${GIT_BRANCH_TAG}
+docker pull vimc/montagu-static-reverse-proxy:${GIT_BRANCH_TAG}
 docker-compose up --force-recreate
 ```
 

--- a/caddy/teamcity-build.sh
+++ b/caddy/teamcity-build.sh
@@ -3,12 +3,12 @@ set -e
 
 GIT_ID=$(git rev-parse --short=7 HEAD)
 GIT_BRANCH=$(git symbolic-ref --short HEAD)
-REGISTRY=docker.montagu.dide.ic.ac.uk:5000
+ORG=vimc
 NAME=montagu-static
 
-APP_DOCKER_TAG=$REGISTRY/$NAME
-APP_DOCKER_COMMIT_TAG=$REGISTRY/$NAME:$GIT_ID
-APP_DOCKER_BRANCH_TAG=$REGISTRY/$NAME:$GIT_BRANCH
+APP_DOCKER_TAG=$ORG/$NAME
+APP_DOCKER_COMMIT_TAG=$ORG/$NAME:$GIT_ID
+APP_DOCKER_BRANCH_TAG=$ORG/$NAME:$GIT_BRANCH
 
 docker build --pull \
        --tag $APP_DOCKER_COMMIT_TAG \

--- a/nginx/build.sh
+++ b/nginx/build.sh
@@ -4,10 +4,10 @@ set -ex
 git_id=$(git rev-parse --short=7 HEAD)
 git_branch=$(git symbolic-ref --short HEAD)
 
-registry=docker.montagu.dide.ic.ac.uk:5000
+org=vimc
 name=montagu-static-reverse-proxy
 
-commit_tag=$registry/$name:$git_id
-branch_tag=$registry/$name:$git_branch
+commit_tag=$org/$name:$git_id
+branch_tag=$org/$name:$git_branch
 
 docker build -t $commit_tag -t $branch_tag .


### PR DESCRIPTION
This whole repo might be deprecated, but for now not having the images on docker hub is a blocker to moving several builds over to buildkite, so this PR updates the build scripts to use docker hub.